### PR TITLE
Amend Embedding post to mention stop() before waitForStop()

### DIFF
--- a/_posts/2011-03-04-embedding-osgi.textile
+++ b/_posts/2011-03-04-embedding-osgi.textile
@@ -66,6 +66,7 @@ For example, if you are writing a straightforward launcher then you probably wan
 
 {% highlight java %}
 try {
+    framework.stop();
     framework.waitForStop(0);
 } finally {
     System.exit(0);


### PR DESCRIPTION
@njbartlett - I've found that, at least in Felix 5.6.1, a stop() is required before waitForStop() ..